### PR TITLE
Fix display primaries order

### DIFF
--- a/modules/webos/ndl/webos5/ndl_video.c
+++ b/modules/webos/ndl/webos5/ndl_video.c
@@ -112,8 +112,8 @@ static bool SetHDRInfo(SS4S_VideoInstance *instance, const SS4S_VideoHDRInfo *in
     if (info == NULL) {
         return true;
     }
-    return NDL_DirectVideoSetHDRInfo(info->displayPrimariesX.b, info->displayPrimariesY.b, info->displayPrimariesX.g,
-                                     info->displayPrimariesY.g, info->displayPrimariesX.r, info->displayPrimariesY.r,
+    return NDL_DirectVideoSetHDRInfo(info->displayPrimariesX.g, info->displayPrimariesY.g, info->displayPrimariesX.b,
+                                     info->displayPrimariesY.b, info->displayPrimariesX.r, info->displayPrimariesY.r,
                                      info->whitePointX, info->whitePointY, info->maxDisplayMasteringLuminance,
                                      info->minDisplayMasteringLuminance, info->maxContentLightLevel,
                                      info->maxPicAverageLightLevel) == 0;

--- a/modules/webos/smp/src/smp_video.c
+++ b/modules/webos/smp/src/smp_video.c
@@ -120,10 +120,10 @@ static bool SetHDRInfo(SS4S_VideoInstance *instance, const SS4S_VideoHDRInfo *in
     jvalue_ref info_json = jobject_create_var(
             jkeyval(J_CSTR_TO_JVAL("hdrType"), J_CSTR_TO_JVAL("HDR10")),
             jkeyval(J_CSTR_TO_JVAL("sei"), jobject_create_var(
-                    jkeyval(J_CSTR_TO_JVAL("displayPrimariesX0"), jnumber_create_i32(info->displayPrimariesX.b)),
-                    jkeyval(J_CSTR_TO_JVAL("displayPrimariesY0"), jnumber_create_i32(info->displayPrimariesY.b)),
-                    jkeyval(J_CSTR_TO_JVAL("displayPrimariesX1"), jnumber_create_i32(info->displayPrimariesX.g)),
-                    jkeyval(J_CSTR_TO_JVAL("displayPrimariesY1"), jnumber_create_i32(info->displayPrimariesY.g)),
+                    jkeyval(J_CSTR_TO_JVAL("displayPrimariesX0"), jnumber_create_i32(info->displayPrimariesX.g)),
+                    jkeyval(J_CSTR_TO_JVAL("displayPrimariesY0"), jnumber_create_i32(info->displayPrimariesY.g)),
+                    jkeyval(J_CSTR_TO_JVAL("displayPrimariesX1"), jnumber_create_i32(info->displayPrimariesX.b)),
+                    jkeyval(J_CSTR_TO_JVAL("displayPrimariesY1"), jnumber_create_i32(info->displayPrimariesY.b)),
                     jkeyval(J_CSTR_TO_JVAL("displayPrimariesX2"), jnumber_create_i32(info->displayPrimariesX.r)),
                     jkeyval(J_CSTR_TO_JVAL("displayPrimariesY2"), jnumber_create_i32(info->displayPrimariesY.r)),
                     jkeyval(J_CSTR_TO_JVAL("whitePointX"), jnumber_create_i32(info->whitePointX)),


### PR DESCRIPTION
According to this PR in XBMC for webos https://github.com/xbmc/xbmc/pull/24918 display primaries expected order in SEI is gbr instead of bgr