### PR TITLE
fix: dlopen leak and stats init on failed video Open

### DIFF
--- a/src/module_libdl.c
+++ b/src/module_libdl.c
@@ -19,6 +19,7 @@ bool SS4S_ModuleOpen(const char *name, SS4S_Module *module, const SS4S_LibraryCo
     SS4S_ModuleOpenFunction *fn = (SS4S_ModuleOpenFunction *) dlsym(lib, tmp);
     if (fn == NULL) {
         SS4S_Log(SS4S_LogLevelError, "Module", "Module `%s` is not valid!", name);
+        dlclose(lib);
         return false;
     }
     memset(module, 0, sizeof(SS4S_Module));

--- a/src/video.c
+++ b/src/video.c
@@ -32,12 +32,15 @@ SS4S_VideoOpenResult SS4S_PlayerVideoOpen(SS4S_Player *player, const SS4S_VideoI
     SS4S_VideoOpenResult result = driver->Open(info, &extraInfo, &player->video, player->context.video);
     if (result == SS4S_VIDEO_OPEN_OK) {
         assert(player->video != NULL);
+        size_t statsCapacity = 120;
+        if (info->frameRateNumerator > 0 && info->frameRateDenominator > 0) {
+            size_t fps = info->frameRateNumerator / info->frameRateDenominator;
+            if (fps > 0) {
+                statsCapacity = fps * 2;
+            }
+        }
+        SS4S_StatsCounterInit(&player->stats.video, statsCapacity);
     }
-    size_t statsCapacity = 120;
-    if (info->frameRateNumerator > 0 && info->frameRateDenominator > 0) {
-        statsCapacity = info->frameRateNumerator / info->frameRateDenominator * 2;
-    }
-    SS4S_StatsCounterInit(&player->stats.video, statsCapacity);
     SS4S_MutexUnlock(player->mutex);
     return result;
 }


### PR DESCRIPTION
## Summary
Two memory-safety fixes found while triaging crash reports in [moonlight-tv](https://github.com/mariotaku/moonlight-tv) (#577, #582, #584).

- **`module: dlclose loaded library when Open symbol missing`** — `SS4S_ModuleOpen` returned without `dlclose()` if the module file loaded but did not export the expected Open symbol. Since the module loader is invoked again on every stream-start (and on every retry after an unstable connection drops the stream), the handle leak accumulated and could eventually exhaust file descriptors.
- **`video: only init stats counter on a successful Open`** — `SS4S_PlayerVideoOpen` called `SS4S_StatsCounterInit()` even when `driver->Open()` reported failure. `PlayerVideoClose` guards its deinit on `player->video` being non-NULL, so a failed Open left the stats counter's malloc'd `items` buffer permanently leaked. Also guarded against an integer-truncated frame rate of zero (e.g. when numerator < denominator) which would have tripped the `capacity > 0` assert inside `SS4S_StatsCounterInit`.

## Test plan
- [ ] Build the moonlight-tv webOS package against this branch — verifies it still compiles cleanly
- [ ] Force-load a non-ss4s shared library as a module and confirm the dlopen handle is released (e.g. with `lsof` against the running process, or `LD_DEBUG=files` on the test rig)
- [ ] Trigger a `SS4S_VIDEO_OPEN_ERROR` path (e.g. by setting an unsupported codec) — confirm no `SS4S_StatsCounter.items` allocation leaks under ASan/Valgrind
- [ ] Stream at a configured frame rate where `frameRateNumerator / frameRateDenominator == 0` (e.g. numerator=1 denominator=2) — must not abort on the capacity assert

🤖 Generated with [Claude Code](https://claude.com/claude-code)