### PR TITLE
fix: ACB handle leak, Opus channel overflow, stats type narrowing

### DIFF
--- a/modules/webos/ndl/webos5/ndl_audio.c
+++ b/modules/webos/ndl/webos5/ndl_audio.c
@@ -184,6 +184,12 @@ bool ParseOpusConfig(const unsigned char *codecData, size_t codecDataLen, OpusCo
     config->channels = codecData[9];
     config->streamCount = codecData[19];
     config->coupledCount = codecData[20];
+    if (config->channels > sizeof(config->mapping)) {
+        // We can only represent up to sizeof(mapping) channels (5.1 layout).
+        // Anything wider (e.g. 7.1 surround = 8 channels) would overflow the
+        // fixed-size mapping array on the memcpy below.
+        return false;
+    }
     if ((int) codecDataLen >= 21 + config->channels) {
         memcpy(config->mapping, codecData + 21, config->channels);
     } else {

--- a/modules/webos/smp/src/smp_resource_acb.c
+++ b/modules/webos/smp/src/smp_resource_acb.c
@@ -19,6 +19,7 @@ StarfishResource *StarfishResourceCreate(const char *appId) {
         return NULL;
     }
     if (!AcbAPI_initialize(res->acbId, PLAYER_TYPE_MSE, appId, AcbCallback)) {
+        AcbAPI_destroy(res->acbId);
         free(res);
         return NULL;
     }

--- a/src/stats.c
+++ b/src/stats.c
@@ -5,12 +5,23 @@
 
 #include "stats.h"
 
-static uint8_t NextIndex(const SS4S_StatsCounter *counter);
+/* BeginFrame returns a 32-bit token that encodes the slot index in
+ * the low 16 bits and a hash of the frame timestamp in the high
+ * 16 bits, so EndFrame can detect that the slot has been recycled
+ * for a different frame. This caps the supported ring-buffer
+ * capacity at 65536, which is more than enough for any plausible
+ * frame rate.
+ */
+#define STATS_INDEX_MASK  0x0000FFFFu
+#define STATS_STAMP_MASK  0xFFFF0000u
+
+static size_t NextIndex(const SS4S_StatsCounter *counter);
 
 static uint64_t GetTimeUs();
 
 void SS4S_StatsCounterInit(SS4S_StatsCounter *counter, size_t capacity) {
     assert(capacity > 0);
+    assert(capacity <= STATS_INDEX_MASK + 1);
     counter->items = (SS4S_StatsItem *) malloc(sizeof(SS4S_StatsItem) * capacity);
     counter->capacity = capacity;
     counter->index = 0;
@@ -26,7 +37,7 @@ void SS4S_StatsCounterDeinit(SS4S_StatsCounter *counter) {
 }
 
 uint32_t SS4S_StatsCounterBeginFrame(SS4S_StatsCounter *counter) {
-    uint8_t index = NextIndex(counter);
+    size_t index = NextIndex(counter);
     counter->index = index;
     counter->items[index].frameTimeUs = GetTimeUs();
     counter->items[index].latencyUs = -1;
@@ -35,23 +46,23 @@ uint32_t SS4S_StatsCounterBeginFrame(SS4S_StatsCounter *counter) {
     } else {
         counter->size = counter->capacity;
     }
-    return index | (counter->items[index].frameTimeUs & 0xFFFFFF00);
+    return (uint32_t) index | ((uint32_t) counter->items[index].frameTimeUs & STATS_STAMP_MASK);
 }
 
 void SS4S_StatsCounterEndFrame(SS4S_StatsCounter *counter, uint32_t beginFrameResult) {
-    uint8_t index = beginFrameResult & 0xFF;
+    size_t index = beginFrameResult & STATS_INDEX_MASK;
     if (index >= counter->capacity) {
         return;
     }
     uint64_t frameTimeUs = counter->items[index].frameTimeUs;
-    if ((frameTimeUs & 0xFFFFFF00) != (beginFrameResult & 0xFFFFFF00)) {
+    if (((uint32_t) frameTimeUs & STATS_STAMP_MASK) != (beginFrameResult & STATS_STAMP_MASK)) {
         return;
     }
     counter->items[index].latencyUs = GetTimeUs() - frameTimeUs;
 }
 
 void SS4S_StatsCounterReportFrame(SS4S_StatsCounter *counter, uint32_t latencyUs) {
-    uint8_t index = NextIndex(counter);
+    size_t index = NextIndex(counter);
     counter->index = index;
     counter->items[index].latencyUs = latencyUs;
     counter->items[index].frameTimeUs = GetTimeUs();
@@ -67,7 +78,8 @@ int32_t SS4S_StatsCounterGetAverageLatencyUs(const SS4S_StatsCounter *counter, u
         return -1;
     }
     uint64_t now = GetTimeUs();
-    uint8_t remSize = counter->size, index = counter->index;
+    size_t remSize = counter->size;
+    size_t index = counter->index;
     uint32_t count = 0, sum = 0;
     while (remSize > 0) {
         index = (index + counter->capacity - 1) % counter->capacity;
@@ -88,7 +100,7 @@ int32_t SS4S_StatsCounterGetAverageLatencyUs(const SS4S_StatsCounter *counter, u
     return (int32_t) (sum / count);
 }
 
-uint8_t NextIndex(const SS4S_StatsCounter *counter) {
+size_t NextIndex(const SS4S_StatsCounter *counter) {
     assert(counter->capacity > 0);
     return (counter->index + 1) % counter->capacity;
 }

--- a/src/stats.h
+++ b/src/stats.h
@@ -9,7 +9,7 @@ typedef struct SS4S_StatsCounter {
     SS4S_StatsItem *items;
     size_t capacity;
     size_t index;
-    unsigned char size;
+    size_t size;
 } SS4S_StatsCounter;
 
 void SS4S_StatsCounterInit(SS4S_StatsCounter *counter, size_t capacity);


### PR DESCRIPTION
## Summary

Three independent ss4s defects found during a fresh audit of the core library and webOS modules. Each commit is reviewable on its own.

1. **`fix(smp): destroy acbId on AcbAPI_initialize failure`** — `StarfishResourceCreate` called `AcbAPI_create`, then on a failed `AcbAPI_initialize` did `free(res)` without first `AcbAPI_destroy(res->acbId)`. webOS has a small fixed pool of ACB handles; the leak compounds on every reconnect after a network drop until the host runs out and refuses new sessions.

2. **`fix(audio): reject Opus configs with channels beyond mapping[]`** — `ParseOpusConfig` read `OpusConfig.channels` (8 bits, network-supplied) and memcpy'd that many bytes into the fixed-size `OpusConfig.mapping[6]`. A 7.1 surround stream (channelCount = 8) overflows the mapping array by two bytes, clobbering the stack frame after `OpusConfig`. The webOS5 NDL module only supports 5.1 anyway, so reject configs with channels > 6 at parse time.

3. **`fix(stats): widen index and size types and the BeginFrame token`** — the stats ring buffer mixed `size_t` (in the header) with `uint8_t` (in NextIndex, BeginFrame assignments, GetAverageLatencyUs locals) and `unsigned char size`. The BeginFrame token packed the slot index into the low 8 bits of a uint32. The effective capacity cap was 256 regardless of the value passed to `SS4S_StatsCounterInit`. With `statsCapacity = frameRateNumerator * 2`, 240Hz+ content silently overflowed: slot 256 mapped to slot 0, EndFrame matched the wrong frame, the size field wrapped mod 256. Widen the ring-buffer types to size_t, re-encode the token as 16-bit index + 16-bit timestamp hash (supported capacity now 65536), and assert the cap so any future increase trips immediately.

## Test plan

- [ ] Existing webOS module tests still pass.
- [ ] Stream a 5.1 surround Opus source on webOS5 NDL — passthrough should still work (no regression).
- [ ] Try to stream a 7.1 surround Opus source on webOS5 NDL — `ParseOpusConfig` returns false, caller falls back to PCM (previously: stack OOB write, undefined behavior).
- [ ] Force ACB resource contention (e.g. by repeatedly starting/stopping streams quickly) and confirm `StarfishResourceCreate` failure no longer accumulates ACB handles. Observable with `lsof` or a webOS API counter if exposed.
- [ ] Stream at 240Hz if a test rig supports it; verify stats reporting matches frame submission rate. With the old code, latency averages would drift / wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
